### PR TITLE
Update .travis.yml to support testing for python 3.6 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev" # 3.5 development branch
-  - "nightly" # currently points to 3.6-dev
+  - "3.5-dev"
+  - "3.6"
+  - "3.6-dev"
+  - "3.7-dev"
+  - "nightly"
 
 install:
   - pip install .


### PR DESCRIPTION
- Execute tests for python 3.6, 3.6-dev, 3.7-dev and nightly