### PR TITLE
Run tests on python 3.8-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "3.6"
   - "3.6-dev"
   - "3.7-dev"
+  - "3.8-dev"
   - "nightly"
 
 install:


### PR DESCRIPTION
- Add `3.8-dev` to .travis.yml