### PR TITLE
Raise TypeError in __eq__ methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Forthcoming
+- Raise TypeError in `__eq__` methods.
+
 ## 0.3.0
 - Implement `__eq__` method for Quality.
 - Fix `__eq__` method of Chord to support comparison between sharped and flatted chords.

--- a/pychord/chord.py
+++ b/pychord/chord.py
@@ -33,6 +33,8 @@ class Chord(object):
         return "<Chord: {}>".format(self._chord)
 
     def __eq__(self, other):
+        if not isinstance(other, Chord):
+            raise TypeError("Cannot compare Chord object with {} object".format(type(other)))
         if note_to_val(self._root) != note_to_val(other.root):
             return False
         if self._quality != other.quality:

--- a/pychord/progression.py
+++ b/pychord/progression.py
@@ -49,6 +49,8 @@ class ChordProgression(object):
         self._chords[key] = value
 
     def __eq__(self, other):
+        if not isinstance(other, ChordProgression):
+            raise TypeError("Cannot compare ChordProgression object with {} object".format(type(other)))
         if len(self) != len(other):
             return False
         for c, o in zip(self, other):

--- a/pychord/quality.py
+++ b/pychord/quality.py
@@ -26,6 +26,8 @@ class Quality(object):
         return self._quality
 
     def __eq__(self, other):
+        if not isinstance(other, Quality):
+            raise TypeError("Cannot compare Quality object with {} object".format(type(other)))
         return self._quality == other.quality
 
     def __ne__(self, other):

--- a/test/test_chord.py
+++ b/test/test_chord.py
@@ -50,6 +50,11 @@ class TestChordCreations(unittest.TestCase):
         c2 = Chord("C")
         self.assertEqual(c1, c2)
 
+    def test_invalid_eq(self):
+        c = Chord("C")
+        with self.assertRaises(TypeError):
+            print(c == 0)
+
 
 class TestAsChord(unittest.TestCase):
 

--- a/test/test_progression.py
+++ b/test/test_progression.py
@@ -110,3 +110,7 @@ class TestChordProgressionFunctions(unittest.TestCase):
         self.assertEqual(cp1, cp2)
         self.assertIsNot(cp1, cp2)
 
+    def test_invalid_eq(self):
+        cp = ChordProgression(["C", "F", "G"])
+        with self.assertRaises(TypeError):
+            print(cp == 0)

--- a/test/test_quality.py
+++ b/test/test_quality.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from pychord import Quality
+
+
+class TestQuality(unittest.TestCase):
+
+    def test_eq(self):
+        c1 = Quality("m7-5")
+        c2 = Quality("m7-5")
+        self.assertEqual(c1, c2)
+
+    def test_invalid_eq(self):
+        c = Quality("m7")
+        with self.assertRaises(TypeError):
+            print(c == 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Raise TypeError in `__eq__` methods
- Add tests for invalid comparison