### PR TITLE
Support 3.8-dev and drop support for 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
   - "3.5-dev"
   - "3.6"
   - "3.6-dev"
+  - "3.7"
   - "3.7-dev"
+  - "3.8-dev"
   - "nightly"
 
 install:


### PR DESCRIPTION
Update travis.yml to support 3.8-dev.
