### PR TITLE
Add Chord.from_note_index method

### DIFF
--- a/pychord/chord.py
+++ b/pychord/chord.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-
-
+from .constants import NOTE_VAL_DICT, VAL_NOTE_DICT
+from .constants.scales import RELATIVE_KEY_DICT
 from .parser import parse
 from .utils import transpose_note, display_appended, display_on, note_to_val
 
@@ -48,6 +48,15 @@ class Chord(object):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+    @classmethod
+    def from_note_index(cls, note, quality, scale):
+        if not 1 <= note <= 8:
+            raise ValueError("Invalid note {}".format(note))
+        relative_key = RELATIVE_KEY_DICT[scale[-3:]][note - 1]
+        root_num = NOTE_VAL_DICT[scale[:-3]]
+        root = VAL_NOTE_DICT[(root_num + relative_key) % 12][0]
+        return cls("{}{}".format(root, quality))
 
     @property
     def chord(self):

--- a/pychord/constants/scales.py
+++ b/pychord/constants/scales.py
@@ -67,7 +67,7 @@ SCALE_VAL_DICT = {
     'G#': SHARPED_SCALE,
 }
 
-RELATIVE_KEY_DICT = {\
-'min': [0,2,3,5,7,8,10,12],\
-'maj': [0,2,4,5,7,9,11,12]\
+RELATIVE_KEY_DICT = {
+    'maj': [0, 2, 4, 5, 7, 9, 11, 12],
+    'min': [0, 2, 3, 5, 7, 8, 10, 12],
 }

--- a/pychord/constants/scales.py
+++ b/pychord/constants/scales.py
@@ -66,3 +66,8 @@ SCALE_VAL_DICT = {
     'G': SHARPED_SCALE,
     'G#': SHARPED_SCALE,
 }
+
+RELATIVE_KEY_DICT = {\
+'min': [0,2,3,5,7,8,10,12],\
+'maj': [0,2,4,5,7,9,11,12]\
+}

--- a/pychord/parser.py
+++ b/pychord/parser.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from .quality import Quality
 from .constants import QUALITY_DICT
-from .constants.scales import RELATIVE_KEY_DICT, FLATTED_SCALE
-from .utils import NOTE_VAL_DICT, note_to_val, transpose_note
+from .quality import Quality
+from .utils import NOTE_VAL_DICT
 
 
 def parse(chord):
@@ -13,42 +12,13 @@ def parse(chord):
     :rtype: (str, pychord.Quality, str, str)
     :return: (root, quality, appended, on)
     """
-    
-    output = chord.split('$')
-    if len(output) == 2:
-        chord = output[0]
-        key = output[1]
-    else:
-        chord = output[0]
-        key = []
-        
+
     if len(chord) > 1 and chord[1] in ("b", "#"):
         root = chord[:2]
         rest = chord[2:]
     else:
         root = chord[:1]
         rest = chord[1:]
-
-    # check if chord is numeric
-    numeric_condition = 0
-    for numeric_key in range(0,10):
-        numeric_condition += 1 if (str(root[0]) == str(numeric_key)) else 0
-    if ( numeric_condition ):
-        if key != []:
-            if len(key) > 1 and chord[1] in ("b", "#"):
-                key_root = key[:2]
-                key_rest = key[2:]
-            else:
-                key_root = key[:1]
-                key_rest = key[1:]
-            relative_key = RELATIVE_KEY_DICT[key_rest][int(root)-1]
-            root = FLATTED_SCALE[\
-                relative_key\
-            ]
-            transpose = note_to_val(key_root) - note_to_val('C')
-            root = transpose_note(root, transpose)
-        else:
-            raise ValueError("No key specified for chord {}.".format(chord))
 
     check_note(root, chord)
     on_chord_idx = rest.find("/")

--- a/pychord/parser.py
+++ b/pychord/parser.py
@@ -13,7 +13,7 @@ def parse(chord):
     :rtype: (str, pychord.Quality, str, str)
     :return: (root, quality, appended, on)
     """
-    # For main chord
+    
     output = chord.split('$')
     if len(output) == 2:
         chord = output[0]
@@ -21,6 +21,7 @@ def parse(chord):
     else:
         chord = output[0]
         key = []
+        
     if len(chord) > 1 and chord[1] in ("b", "#"):
         root = chord[:2]
         rest = chord[2:]
@@ -32,8 +33,7 @@ def parse(chord):
     numeric_condition = 0
     for numeric_key in range(0,10):
         numeric_condition += 1 if (str(root[0]) == str(numeric_key)) else 0
-    if ( numeric_condition ): # if numeric chord
-        # Determine scale quality
+    if ( numeric_condition ):
         if key != []:
             if len(key) > 1 and chord[1] in ("b", "#"):
                 key_root = key[:2]
@@ -44,9 +44,9 @@ def parse(chord):
             relative_key = RELATIVE_KEY_DICT[key_rest][int(root)-1]
             root = FLATTED_SCALE[\
                 relative_key\
-            ] # shift root relative to C scale
-            transpose = note_to_val(key_root) - note_to_val('C') # shift scale relative to C key
-            root = transpose_note(root, transpose) # transpose root
+            ]
+            transpose = note_to_val(key_root) - note_to_val('C')
+            root = transpose_note(root, transpose)
         else:
             raise ValueError("No key specified for chord {}.".format(chord))
 

--- a/test/test_chord.py
+++ b/test/test_chord.py
@@ -73,5 +73,36 @@ class TestAsChord(unittest.TestCase):
             as_chord(1)
 
 
+class TestChordFromNoteIndex(unittest.TestCase):
+
+    def test_note_1(self):
+        chord = Chord.from_note_index(note=1, quality="", scale="Cmaj")
+        self.assertEqual(chord, Chord("C"))
+
+    def test_note_2(self):
+        chord = Chord.from_note_index(note=2, quality="m7", scale="F#min")
+        self.assertEqual(chord, Chord("G#m7"))
+
+    def test_note_3(self):
+        chord = Chord.from_note_index(note=3, quality="sus2", scale="Cmin")
+        self.assertEqual(chord, Chord("Ebsus2"))
+
+    def test_note_7(self):
+        chord = Chord.from_note_index(note=7, quality="7", scale="Amin")
+        self.assertEqual(chord, Chord("G7"))
+
+    def test_note_8(self):
+        chord = Chord.from_note_index(note=8, quality="", scale="Emaj")
+        self.assertEqual(chord, Chord("E"))
+
+    def test_note_0(self):
+        with self.assertRaises(ValueError):
+            Chord.from_note_index(note=0, quality="", scale="Cmaj")
+
+    def test_note_9(self):
+        with self.assertRaises(ValueError):
+            Chord.from_note_index(note=9, quality="", scale="Fmaj")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Support chord creation using note index in a scale (proposed in #30).

```python
>>> from pychord import Chord
>>> chord = Chord.from_note_index(note=3, quality="sus2", scale="Cmin")
>>> chord
<Chord: Ebsus2>
```

Contributor: @kwadwo00