### PR TITLE
Fixing Chord.from_note_index() so it chooses the correct accidentals

### DIFF
--- a/pychord/chord.py
+++ b/pychord/chord.py
@@ -2,7 +2,7 @@
 from .constants import NOTE_VAL_DICT, VAL_NOTE_DICT
 from .constants.scales import RELATIVE_KEY_DICT
 from .parser import parse
-from .utils import transpose_note, display_appended, display_on, note_to_val
+from .utils import transpose_note, display_appended, display_on, note_to_val, sharp_or_flat
 
 
 class Chord(object):
@@ -66,7 +66,16 @@ class Chord(object):
             raise ValueError("Invalid note {}".format(note))
         relative_key = RELATIVE_KEY_DICT[scale[-3:]][note - 1]
         root_num = NOTE_VAL_DICT[scale[:-3]]
-        root = VAL_NOTE_DICT[(root_num + relative_key) % 12][0]
+        
+        # choose the sharp/flat note depending on the underlying scale
+        root_options = VAL_NOTE_DICT[(root_num + relative_key) % 12]
+        if len(root_options) == 1:
+            root = root_options[0]
+        else:
+            correct_accidental = sharp_or_flat(scale)
+            correct_index = ['FLATTED','SHARPED'].index(correct_accidental)
+            root = root_options[correct_index]
+
         return cls("{}{}".format(root, quality))
 
     @property
@@ -161,3 +170,4 @@ def as_chord(chord):
         return Chord(chord)
     else:
         raise TypeError("input type should be str or Chord instance.")
+

--- a/pychord/constants/__init__.py
+++ b/pychord/constants/__init__.py
@@ -1,2 +1,2 @@
 from .qualities import QUALITY_DICT
-from .scales import NOTE_VAL_DICT, VAL_NOTE_DICT, SCALE_VAL_DICT
+from .scales import NOTE_VAL_DICT, VAL_NOTE_DICT, SCALE_VAL_DICT, SHARPED_SCALE

--- a/pychord/utils.py
+++ b/pychord/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from .constants import NOTE_VAL_DICT, SCALE_VAL_DICT
+from .constants import NOTE_VAL_DICT, SCALE_VAL_DICT, SHARPED_SCALE
 
 
 def note_to_val(note):
@@ -58,3 +58,24 @@ def display_on(on_note):
     if on_note:
         return "/{}".format(on_note)
     return ""
+
+def sharp_or_flat(scale):
+    """ Determine whether the scale provided uses flats or sharps
+
+        sharp_or_flat('Cmaj') returns flats => 'FLATTED'
+        sharp_or_flat('C#min') returns sharps => 'SHARPED'
+        
+        :param str scale: Base scale (Cmaj, Amin, F#maj, Ebmin, ...)
+        :rtype: str
+        """
+    root = scale[:-3]
+    # if scale is minor, get sharp/flat from relative major
+    if scale[-3:] == 'min':
+        root = SCALE_VAL_DICT[root][3]
+    
+    # figure out whether sharps or flats are correct
+    if SCALE_VAL_DICT[root] == SHARPED_SCALE:
+        return 'SHARPED'
+    else:
+        return 'FLATTED'
+    


### PR DESCRIPTION
I have noticed that the from_note_index class method does some possibly undesirable things with accidentals. For example, 
```
from pychord import Chord
Chord.from_note_index(3,'','Emaj')`
```
returns `<Chord: Ab>`.

I have used your `SHARPED_SCALE` constant and a helper function `utils.sharp_or_flat` to use the underlying scale to determine the correct accidental. In this example, this makes the function return `<Chord: G#>' instead, which is more conventional.

It also makes `TestChordFromNoteIndex.test_note_2` from `test_chord.py` pass (it was previously failing).
