### PR TITLE
Drop Python 3.4 and add Python 3.9 on build test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ dist: xenial
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
   - "nightly"
 
 install:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ True
 ## Supported Python Versions
 
 - 2.7
-- 3.4 and above
+- 3.5 and above
 
 ## Links
 


### PR DESCRIPTION
- Drop Python 3.4 and add Python 3.9 on Travis CI