### PR TITLE
Create QualityManager class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Forthcoming
 
 - Add an example to create a MIDI file.
+- Add `QualityManager` class to overwrite default qualities.
+    - Do not import `QUALITY_DICT` from modules other than quality.
 
 ## v0.5.1
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ True
 <Chord: E7>  # V7 of A minor
 ```
 
+### Overwrite the default Quality components with yours
+
+```python
+>>> from pychord import Chord, QualityManager
+>>> Chord("C11").components()
+['C', 'G', 'Bb', 'D', 'F']
+
+>>> quality_manager = QualityManager()
+>>> quality_manager.set_quality("11", (0, 4, 7, 10, 14, 17))
+>>> Chord("C11").components()
+['C', 'E', 'G', 'Bb', 'D', 'F']
+```
+
 ## Examples
 
 - [pychord-midi.py](./examples/pychord-midi.py) - Create a MIDI file using PyChord and pretty_midi.

--- a/pychord/__init__.py
+++ b/pychord/__init__.py
@@ -1,4 +1,4 @@
 from .analyzer import note_to_chord
 from .chord import Chord
 from .progression import ChordProgression
-from .quality import Quality
+from .quality import Quality, QualityManager

--- a/pychord/analyzer.py
+++ b/pychord/analyzer.py
@@ -21,7 +21,7 @@ def note_to_chord(notes):
         root_and_positions.append([rotated_root, notes_to_positions(rotated_notes, rotated_notes[0])])
     chords = []
     for temp_root, positions in root_and_positions:
-        quality = QualityManager().from_components(positions)
+        quality = QualityManager().find_quality_from_components(positions)
         if quality is None:
             continue
         if temp_root == root:

--- a/pychord/analyzer.py
+++ b/pychord/analyzer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from .chord import Chord
-from .constants.qualities import QUALITY_DICT
+from .quality import QualityManager
 from .utils import note_to_val
 
 
@@ -21,7 +21,7 @@ def note_to_chord(notes):
         root_and_positions.append([rotated_root, notes_to_positions(rotated_notes, rotated_notes[0])])
     chords = []
     for temp_root, positions in root_and_positions:
-        quality = find_quality(positions)
+        quality = QualityManager().from_components(positions)
         if quality is None:
             continue
         if temp_root == root:
@@ -66,15 +66,3 @@ def get_all_rotated_notes(notes):
     for x in range(len(notes)):
         notes_list.append(notes[x:] + notes[:x])
     return notes_list
-
-
-def find_quality(positions):
-    """ Find a quality consists of positions
-
-    :param list[int] positions: note positions
-    :rtype: str|None
-    """
-    for q, p in QUALITY_DICT.items():
-        if positions == list(p):
-            return q
-    return None

--- a/pychord/constants/__init__.py
+++ b/pychord/constants/__init__.py
@@ -1,2 +1,1 @@
-from .qualities import QUALITY_DICT
 from .scales import NOTE_VAL_DICT, VAL_NOTE_DICT, SCALE_VAL_DICT

--- a/pychord/constants/qualities.py
+++ b/pychord/constants/qualities.py
@@ -1,8 +1,6 @@
-# -*- coding, utf-8 -*-
-
 from collections import OrderedDict
 
-QUALITY_DICT = OrderedDict((
+DEFAULT_QUALITY_DICT = OrderedDict((
     # chords consist of 2 notes
     ('5', (0, 7)),
     ('sus', (0, 7)),

--- a/pychord/constants/qualities.py
+++ b/pychord/constants/qualities.py
@@ -1,6 +1,4 @@
-from collections import OrderedDict
-
-DEFAULT_QUALITY_DICT = OrderedDict((
+DEFAULT_QUALITIES = [
     # chords consist of 2 notes
     ('5', (0, 7)),
     ('sus', (0, 7)),
@@ -76,4 +74,4 @@ DEFAULT_QUALITY_DICT = OrderedDict((
     ('13#9', (0, 4, 7, 10, 15, 21)),
     ('13+11', (0, 4, 7, 10, 18, 21)),
     ('13#11', (0, 4, 7, 10, 18, 21)),
-))
+]

--- a/pychord/parser.py
+++ b/pychord/parser.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from .constants import QUALITY_DICT
-from .quality import Quality
+from .quality import QualityManager
 from .utils import NOTE_VAL_DICT
 
 
@@ -28,10 +27,7 @@ def parse(chord):
         check_note(on, chord)
     else:
         on = None
-    if rest in QUALITY_DICT:
-        quality = Quality(rest)
-    else:
-        raise ValueError("Invalid chord {}: Unknown quality {}".format(chord, rest))
+    quality = QualityManager().get_quality(rest)
     # TODO: Implement parser for appended notes
     appended = []
     return root, quality, appended, on

--- a/pychord/quality.py
+++ b/pychord/quality.py
@@ -135,5 +135,5 @@ class QualityManager(object):
     def find_quality_from_components(self, components):
         for q in self._qualities.values():
             if q.components == components:
-                return q
+                return copy.deepcopy(q)
         return None

--- a/pychord/quality.py
+++ b/pychord/quality.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import copy
+from collections import OrderedDict
 
-from .constants.qualities import DEFAULT_QUALITY_DICT
+from .constants.qualities import DEFAULT_QUALITIES
 from .utils import note_to_val, val_to_note
 
 
@@ -113,9 +114,9 @@ class QualityManager(object):
         return cls._instance
 
     def load_default_qualities(self):
-        self._qualities = {
-            q: Quality(q, c) for q, c in DEFAULT_QUALITY_DICT.items()
-        }
+        self._qualities = OrderedDict([
+            (q, Quality(q, c)) for q, c in DEFAULT_QUALITIES
+        ])
 
     def get_quality(self, name):
         if name not in self._qualities:

--- a/pychord/quality.py
+++ b/pychord/quality.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from .constants import QUALITY_DICT
+import copy
+
+from .constants.qualities import DEFAULT_QUALITY_DICT
 from .utils import note_to_val, val_to_note
 
 
@@ -8,15 +10,14 @@ class Quality(object):
 
     :param str _quality: str expression of chord quality
     """
-    def __init__(self, quality):
+    def __init__(self, name, components):
         """ Constructor of chord quality
 
-        :param str quality: name of quality
+        :param str name: name of quality
+        :param Tuple[int]: components of quality
         """
-        if quality not in QUALITY_DICT:
-            raise ValueError("unknown quality {}".format(quality))
-        self._quality = quality
-        self.components = list(QUALITY_DICT[quality])
+        self._quality = name
+        self.components = list(components)
 
     def __unicode__(self):
         return self._quality
@@ -27,7 +28,7 @@ class Quality(object):
     def __eq__(self, other):
         if not isinstance(other, Quality):
             raise TypeError("Cannot compare Quality object with {} object".format(type(other)))
-        return QUALITY_DICT[self._quality] == QUALITY_DICT[other.quality]
+        return self.components == other.components
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -100,3 +101,39 @@ class Quality(object):
         """
         for note in notes:
             self.append_note(note, root, scale)
+
+
+class QualityManager(object):
+    """ Singleton class to manage the qualities """
+
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, "_instance"):
+            cls._instance = super(QualityManager, cls).__new__(cls)
+            cls._instance.load_default()
+        return cls._instance
+
+    def load_default(self):
+        self._qualities = {
+            q: Quality(q, c) for q, c in DEFAULT_QUALITY_DICT.items()
+        }
+
+    def get_quality(self, name):
+        if name not in self._qualities:
+            raise ValueError("Unknown quality: {}".format(name))
+        # Create a new instance not to affect any existing instances
+        return copy.deepcopy(self._qualities[name])
+
+    def set_quality(self, name, components):
+        """ Set a Quality
+
+        This method will not affect any existing Chord instances.
+        :param str name: name of quality
+        :param Tuple[int] components: components of quality
+        """
+        self._qualities[name] = Quality(name, components)
+
+    def from_components(self, components):
+        for q in self._qualities.values():
+            if q.components == components:
+                return q
+        return None

--- a/pychord/quality.py
+++ b/pychord/quality.py
@@ -109,10 +109,10 @@ class QualityManager(object):
     def __new__(cls, *args, **kwargs):
         if not hasattr(cls, "_instance"):
             cls._instance = super(QualityManager, cls).__new__(cls)
-            cls._instance.load_default()
+            cls._instance.load_default_qualities()
         return cls._instance
 
-    def load_default(self):
+    def load_default_qualities(self):
         self._qualities = {
             q: Quality(q, c) for q, c in DEFAULT_QUALITY_DICT.items()
         }
@@ -132,7 +132,7 @@ class QualityManager(object):
         """
         self._qualities[name] = Quality(name, components)
 
-    def from_components(self, components):
+    def find_quality_from_components(self, components):
         for q in self._qualities.values():
             if q.components == components:
                 return q

--- a/test/test_quality.py
+++ b/test/test_quality.py
@@ -46,17 +46,17 @@ class TestQualityManager(unittest.TestCase):
 
 
 class TestOverwriteQuality(unittest.TestCase):
+    def setUp(self):
+        self.quality_manager = QualityManager()
 
     def test_overwrite(self):
-        quality_manager = QualityManager()
-        quality_manager.set_quality("11", (0, 4, 7, 10, 14, 17))
+        self.quality_manager.set_quality("11", (0, 4, 7, 10, 14, 17))
         chord = Chord("C11")
         self.assertEqual(chord.components(), ['C', 'E', 'G', 'Bb', 'D', 'F'])
 
     def test_keep_existing_chord(self):
         chord = Chord("C11")
-        quality_manager = QualityManager()
-        quality_manager.set_quality("11", (0, 4, 7, 10, 14, 17))
+        self.quality_manager.set_quality("11", (0, 4, 7, 10, 14, 17))
         self.assertEqual(chord.components(), ['C', 'G', 'Bb', 'D', 'F'])
 
 

--- a/test/test_quality.py
+++ b/test/test_quality.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from pychord import QualityManager, Chord
+from pychord import QualityManager, Chord, note_to_chord
 
 
 class TestQuality(unittest.TestCase):
@@ -49,10 +49,18 @@ class TestOverwriteQuality(unittest.TestCase):
     def setUp(self):
         self.quality_manager = QualityManager()
 
+    def tearDown(self):
+        self.quality_manager.load_default_qualities()
+
     def test_overwrite(self):
         self.quality_manager.set_quality("11", (0, 4, 7, 10, 14, 17))
         chord = Chord("C11")
         self.assertEqual(chord.components(), ['C', 'E', 'G', 'Bb', 'D', 'F'])
+
+    def test_find_from_components(self):
+        self.quality_manager.set_quality("13", (0, 4, 7, 10, 14, 17, 21))
+        chords = note_to_chord(['C', 'E', 'G', 'Bb', 'D', 'F', 'A'])
+        self.assertEqual(chords, [Chord("C13")])
 
     def test_keep_existing_chord(self):
         chord = Chord("C11")

--- a/test/test_quality.py
+++ b/test/test_quality.py
@@ -2,37 +2,62 @@
 
 import unittest
 
-from pychord import Quality
+from pychord import QualityManager, Chord
 
 
 class TestQuality(unittest.TestCase):
+    def setUp(self):
+        self.quality_manager = QualityManager()
 
     def test_eq(self):
-        c1 = Quality("m7-5")
-        c2 = Quality("m7-5")
-        self.assertEqual(c1, c2)
+        q1 = self.quality_manager.get_quality("m7-5")
+        q2 = self.quality_manager.get_quality("m7-5")
+        self.assertEqual(q1, q2)
 
     def test_eq_alias_maj9(self):
-        c1 = Quality("M9")
-        c2 = Quality("maj9")
-        self.assertEqual(c1, c2)
+        q1 = self.quality_manager.get_quality("M9")
+        q2 = self.quality_manager.get_quality("maj9")
+        self.assertEqual(q1, q2)
 
     def test_eq_alias_m7b5(self):
-        c1 = Quality("m7-5")
-        c2 = Quality("m7b5")
-        self.assertEqual(c1, c2)
+        q1 = self.quality_manager.get_quality("m7-5")
+        q2 = self.quality_manager.get_quality("m7b5")
+        self.assertEqual(q1, q2)
 
     def test_eq_alias_min(self):
-        c1 = Quality("m")
-        c2 = Quality("min")
-        c3 = Quality("-")
-        self.assertEqual(c1, c2)
-        self.assertEqual(c1, c3)
+        q1 = self.quality_manager.get_quality("m")
+        q2 = self.quality_manager.get_quality("min")
+        q3 = self.quality_manager.get_quality("-")
+        self.assertEqual(q1, q2)
+        self.assertEqual(q1, q3)
 
     def test_invalid_eq(self):
-        c = Quality("m7")
+        q = self.quality_manager.get_quality("m7")
         with self.assertRaises(TypeError):
-            print(c == 0)
+            print(q == 0)
+
+
+class TestQualityManager(unittest.TestCase):
+
+    def test_singleton(self):
+        quality_manager = QualityManager()
+        quality_manager2 = QualityManager()
+        self.assertIs(quality_manager, quality_manager2)
+
+
+class TestOverwriteQuality(unittest.TestCase):
+
+    def test_overwrite(self):
+        quality_manager = QualityManager()
+        quality_manager.set_quality("11", (0, 4, 7, 10, 14, 17))
+        chord = Chord("C11")
+        self.assertEqual(chord.components(), ['C', 'E', 'G', 'Bb', 'D', 'F'])
+
+    def test_keep_existing_chord(self):
+        chord = Chord("C11")
+        quality_manager = QualityManager()
+        quality_manager.set_quality("11", (0, 4, 7, 10, 14, 17))
+        self.assertEqual(chord.components(), ['C', 'G', 'Bb', 'D', 'F'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Create `QualityManager` class to overwrite default quality components #58.

```python
from pychord import Chord, QualityManager
c1 = Chord("C11")
print(c1.components())
# ['C', 'G', 'Bb', 'D', 'F']

quality_manager = QualityManager()
quality_manager.set_quality("11", (0, 4, 7, 10, 14, 17))
c2 = Chord("C11")
print(c2.components())
# ['C', 'E', 'G', 'Bb', 'D', 'F']

# will not affect existing chord instances
print(c1.components())
# ['C', 'G', 'Bb', 'D', 'F']
```