### PR TITLE
Create chords diatonically

### DIFF
--- a/pychord/chord.py
+++ b/pychord/chord.py
@@ -50,7 +50,7 @@ class Chord(object):
         return not self.__eq__(other)
 
     @classmethod
-    def from_note_index(cls, note, quality, scale):
+    def from_note_index(cls, note, quality, scale, diatonic=False):
         """ Create a Chord from note index in a scale
 
         Chord.from_note_index(1, "", "Cmaj") returns I of C major => Chord("C")
@@ -67,6 +67,49 @@ class Chord(object):
         relative_key = RELATIVE_KEY_DICT[scale[-3:]][note - 1]
         root_num = NOTE_VAL_DICT[scale[:-3]]
         root = VAL_NOTE_DICT[(root_num + relative_key) % 12][0]
+
+        scale_degrees = RELATIVE_KEY_DICT[scale[-3:]]
+
+        if diatonic:
+
+            from .constants.qualities import DEFAULT_QUALITIES
+            from collections import OrderedDict
+
+            # construct the chord based on scale degrees, within 1 octave
+            third = scale_degrees[(note + 1) % 7]
+            fifth = scale_degrees[(note + 3) % 7]
+            seventh = scale_degrees[(note + 5) % 7]
+
+            # adjust the chord to its root position (as a stack of thirds),
+            # then set the root to 0
+            def get_diatonic_chord(chord: tuple):
+                uninverted = []
+                for note in chord:
+                    if not uninverted:
+                        uninverted.append(note)
+                    elif note > uninverted[-1]:
+                        uninverted.append(note)
+                    else:
+                        uninverted.append(note + 12)
+                uninverted = tuple([x - uninverted[0] for x in uninverted])
+                return uninverted
+
+            if quality in ["", "-", "maj", "m", "min"]:
+                triad = (relative_key, third, fifth)
+                q = get_diatonic_chord(triad)
+            elif quality in ["7", "M7", "maj7", "m7"]:
+                seventh_chord = (relative_key, third, fifth, seventh)
+                q = get_diatonic_chord(seventh_chord)
+            else:
+                raise NotImplementedError("Only generic chords (triads, sevenths) are supported")
+
+            # look up DEFAULT_QUALITIES to determine chord quality
+            # tuples are used as keys for easier lookup
+            # note: because first matching tuple is used, (0, 3, 7) becomes
+            # "-", which might not be preferred by some
+            qualities = OrderedDict([(c, q) for q, c in DEFAULT_QUALITIES])
+            quality = qualities[q]
+
         return cls("{}{}".format(root, quality))
 
     @property

--- a/pychord/constants/qualities.py
+++ b/pychord/constants/qualities.py
@@ -1,3 +1,5 @@
+# Do not import DEFAULT_QUALITIES directly
+# Use QualityManager instead
 DEFAULT_QUALITIES = [
     # chords consist of 2 notes
     ('5', (0, 7)),

--- a/pychord/constants/scales.py
+++ b/pychord/constants/scales.py
@@ -67,7 +67,14 @@ SCALE_VAL_DICT = {
     'G#': SHARPED_SCALE,
 }
 
+# https://en.wikipedia.org/wiki/Mode_(music)#Modern_modes
+# Ionian -> maj, Aeolian -> min
 RELATIVE_KEY_DICT = {
     'maj': [0, 2, 4, 5, 7, 9, 11, 12],
+    'Dor': [0, 2, 3, 5, 7, 9, 10, 12],
+    'Phr': [0, 1, 3, 5, 7, 8, 10, 12],
+    'Lyd': [0, 2, 4, 6, 7, 9, 11, 12],
+    'Mix': [0, 2, 4, 5, 7, 9, 10, 12],
     'min': [0, 2, 3, 5, 7, 8, 10, 12],
+    'Loc': [0, 1, 3, 5, 6, 8, 10, 12],
 }

--- a/pychord/quality.py
+++ b/pychord/quality.py
@@ -134,7 +134,11 @@ class QualityManager(object):
         self._qualities[name] = Quality(name, components)
 
     def find_quality_from_components(self, components):
+        """ Find a quality from components
+
+        :param Tuple[int] components: components of quality
+        """
         for q in self._qualities.values():
-            if q.components == components:
+            if q.components == list(components):
                 return copy.deepcopy(q)
         return None

--- a/test/test_chord.py
+++ b/test/test_chord.py
@@ -123,6 +123,26 @@ class TestChordFromNoteIndex(unittest.TestCase):
         with self.assertRaises(ValueError):
             Chord.from_note_index(note=9, quality="", scale="Fmaj")
 
+    def test_diatonic_note_1(self):
+        chord = Chord.from_note_index(note=1, quality="", diatonic=True, scale="Dmaj")
+        self.assertEqual(chord, Chord("D"))
+
+    def test_diatonic_note_2_mode(self):
+        chord = Chord.from_note_index(note=2, quality="7", diatonic=True, scale="BLoc")
+        self.assertEqual(chord, Chord("Cmaj7"))
+
+    def test_diatonic_note_3_mode(self):
+        chord = Chord.from_note_index(note=3, quality="m", diatonic=True, scale="G#Mix")
+        self.assertEqual(chord, Chord("Cdim"))
+
+    def test_diatonic_note_4_mode(self):
+        chord = Chord.from_note_index(note=4, quality="-", diatonic=True, scale="AbDor")
+        self.assertEqual(chord, Chord("C#"))
+
+    def test_diatonic_note_nongeneric(self):
+        with self.assertRaises(NotImplementedError):
+            Chord.from_note_index(note=5, quality="sus", diatonic=True, scale="Fmaj")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This attempts to address https://github.com/yuma-m/pychord/issues/66.

Usage:

```
>>> Chord.from_note_index(note=2, quality="", scale="Cmaj", diatonic=True)
<Chord: D->
```

(I made a new branch to split this from my main one, where I made PR https://github.com/yuma-m/pychord/pull/65; some of the commits from that branch appear here)