### PR TITLE
Drop Python 2.7 and 3.5 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -18,3 +18,11 @@ jobs:
     - name: Run test
       run: |
         python setup.py test
+    - name: Style check
+      run: |
+        pip install flake8
+        flake8 --ignore=E501 pychord test
+    - name: Type check
+      run: |
+        pip install mypy
+        mypy pychord

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Forthcoming
 
+- Drop compatibility for Python 2.7 and 3.5
+- Refactor whole library to optimize for Python 3.x
+
 ## v0.6.3
 
 - Add modes to `RELATIVE_KEY_DICT`.

--- a/README.md
+++ b/README.md
@@ -63,16 +63,16 @@ True
 True
 ```
 
-### Find Chords
+### Find Chords from notes
 
 ```python
->>> from pychord import note_to_chord
->>> note_to_chord(["C", "E", "G"])
-[<Chord: C>]
->>> note_to_chord(["F#", "A", "C", "D"])
-[<Chord: D7/F#>]
->>> note_to_chord(["F", "G", "C"])
-[<Chord: Fsus2>, <Chord: Csus4/F>]
+>>> from pychord import find_chords_from_notes
+>>> find_chords_from_notes(["C", "E", "G"])
+[ <Chord: C>]
+>>> find_chords_from_notes(["F#", "A", "C", "D"])
+[ <Chord: D7/F#>]
+>>> find_chords_from_notes(["F", "G", "C"])
+[ <Chord: Fsus2>, <Chord: Csus4/F>]
 ```
 
 ### Create and handle chord progressions
@@ -127,8 +127,9 @@ True
 
 ## Supported Python Versions
 
-- 2.7
-- 3.5 and above
+- 3.6 and above
+
+Python 2.7 and 3.5 compatibility was dropped from version 1.0.0.
 
 ## Links
 
@@ -144,4 +145,4 @@ True
 
 - MIT License
 
-Icon is made by [Freepik](https://www.flaticon.com/authors/freepik")
+Icon is made by [Freepik](https://www.flaticon.com/authors/freepik).

--- a/pychord/__init__.py
+++ b/pychord/__init__.py
@@ -1,4 +1,5 @@
-from .analyzer import note_to_chord
+# flake8: noqa
+from .analyzer import find_chords_from_notes
 from .chord import Chord
 from .progression import ChordProgression
 from .quality import Quality, QualityManager

--- a/pychord/analyzer.py
+++ b/pychord/analyzer.py
@@ -1,16 +1,15 @@
-# -*- coding: utf-8 -*-
+from typing import List
 
 from .chord import Chord
 from .quality import QualityManager
 from .utils import note_to_val
 
 
-def note_to_chord(notes):
-    """ Convert note list to chord list
+def find_chords_from_notes(notes: List[str]) -> List[Chord]:
+    """ Find possible chords consisted from notes
 
-    :param list[str] notes: list of note arranged from lower note. ex) ["C", "Eb", "G"]
-    :rtype: list[pychord.Chord]
-    :return: list of chord
+    :param notes: List of note arranged from lower note. ex) ["C", "Eb", "G"]
+    :return: List of chord
     """
     if not notes:
         raise ValueError("Please specify notes which consist a chord.")
@@ -18,7 +17,7 @@ def note_to_chord(notes):
     root_and_positions = []
     for rotated_notes in get_all_rotated_notes(notes):
         rotated_root = rotated_notes[0]
-        root_and_positions.append([rotated_root, notes_to_positions(rotated_notes, rotated_notes[0])])
+        root_and_positions.append((rotated_root, notes_to_positions(rotated_notes, rotated_notes[0])))
     chords = []
     for temp_root, positions in root_and_positions:
         quality = QualityManager().find_quality_from_components(positions)
@@ -32,15 +31,15 @@ def note_to_chord(notes):
     return chords
 
 
-def notes_to_positions(notes, root):
-    """ Get notes positions.
+def notes_to_positions(notes: List[str], root: str) -> List[int]:
+    """ Get notes positions from the root note
 
-    ex) notes_to_positions(["C", "E", "G"], "C") -> [0, 4, 7]
+    >>> notes_to_positions(["C", "E", "G"], "C")
+    [0, 4, 7]
 
-    :param list[str] notes: list of notes
-    :param str root: the root note
-    :rtype: list[int]
-    :return: list of note positions
+    :param notes: List of notes
+    :param root: Root note
+    :return: List of note positions
     """
     root_pos = note_to_val(root)
     current_pos = root_pos
@@ -54,13 +53,10 @@ def notes_to_positions(notes, root):
     return positions
 
 
-def get_all_rotated_notes(notes):
+def get_all_rotated_notes(notes: List[str]) -> List[List[str]]:
     """ Get all rotated notes
 
-    get_all_rotated_notes([1,3,5]) -> [[1,3,5],[3,5,1],[5,1,3]]
-
-    :type notes: list[str]
-    :rtype: list[list[str]]
+    get_all_rotated_notes([A,C,E]) -> [[A,C,E],[C,E,A],[E,A,C]]
     """
     notes_list = []
     for x in range(len(notes)):

--- a/pychord/constants/__init__.py
+++ b/pychord/constants/__init__.py
@@ -1,1 +1,2 @@
+# flake8: noqa
 from .scales import NOTE_VAL_DICT, VAL_NOTE_DICT, SCALE_VAL_DICT

--- a/pychord/parser.py
+++ b/pychord/parser.py
@@ -1,14 +1,13 @@
-# -*- coding: utf-8 -*-
+from typing import Tuple, List
 
-from .quality import QualityManager
+from .quality import QualityManager, Quality
 from .utils import NOTE_VAL_DICT
 
 
-def parse(chord):
+def parse(chord: str) -> Tuple[str, Quality, List[str], str]:
     """ Parse a string to get chord component
 
-    :param str chord: str expression of a chord
-    :rtype: (str, pychord.Quality, str, str)
+    :param chord: str expression of a chord
     :return: (root, quality, appended, on)
     """
 
@@ -19,27 +18,20 @@ def parse(chord):
         root = chord[:1]
         rest = chord[1:]
 
-    check_note(root, chord)
+    def check_note(note: str):
+        """ Raise ValueError if note is invalid """
+        if note not in NOTE_VAL_DICT:
+            raise ValueError(f"Invalid note {note}")
+
+    check_note(root)
     on_chord_idx = rest.find("/")
     if on_chord_idx >= 0:
         on = rest[on_chord_idx + 1:]
         rest = rest[:on_chord_idx]
-        check_note(on, chord)
+        check_note(on)
     else:
-        on = None
+        on = ""
     quality = QualityManager().get_quality(rest)
     # TODO: Implement parser for appended notes
-    appended = []
+    appended: List[str] = []
     return root, quality, appended, on
-
-
-def check_note(note, chord):
-    """ Return True if the note is valid.
-
-    :param str note: note to check its validity
-    :param str chord: the chord which includes the note
-    :rtype: bool
-    """
-    if note not in NOTE_VAL_DICT:
-        raise ValueError("Invalid chord {}: Unknown note {}".format(chord, note))
-    return True

--- a/pychord/progression.py
+++ b/pychord/progression.py
@@ -1,30 +1,31 @@
-# -*- coding: utf-8 -*-
+from typing import Union, List
 
-from .chord import as_chord, Chord
+from .chord import Chord
 
 
-class ChordProgression(object):
+class ChordProgression:
     """ Class to handle chord progressions.
 
-    :param list[pychord.Chord] _chords: component chords of chord progression.
+    Attributes:
+        _chords: component chords of chord progression.
     """
 
-    def __init__(self, initial_chords=None):
+    def __init__(self, initial_chords: Union[str, Chord, List[Union[str, Chord]]] = None):
         """ Constructor of ChordProgression instance.
 
-        :type initial_chords: str|pychord.Chord|list
         :param initial_chords: Initial chord or chords of the chord progressions
         """
         if initial_chords is None:
             initial_chords = []
         if isinstance(initial_chords, Chord):
-            self._chords = [initial_chords]
+            chords = [initial_chords]
         elif isinstance(initial_chords, str):
-            self._chords = [as_chord(initial_chords)]
+            chords = [self._as_chord(initial_chords)]
         elif isinstance(initial_chords, list):
-            self._chords = [as_chord(chord) for chord in initial_chords]
+            chords = [self._as_chord(chord) for chord in initial_chords]
         else:
-            raise TypeError("Cannot initialize ChordProgression with argument of {} type".format(type(initial_chords)))
+            raise TypeError(f"Cannot initialize ChordProgression with argument of {type(initial_chords)} type")
+        self._chords: List[Chord] = chords
 
     def __unicode__(self):
         return " | ".join([chord.chord for chord in self._chords])
@@ -33,7 +34,7 @@ class ChordProgression(object):
         return " | ".join([chord.chord for chord in self._chords])
 
     def __repr__(self):
-        return "<ChordProgression: {}>".format(" | ".join([chord.chord for chord in self._chords]))
+        return f"<ChordProgression: {' | '.join([chord.chord for chord in self._chords])}>"
 
     def __add__(self, other):
         self._chords += other.chords
@@ -50,7 +51,7 @@ class ChordProgression(object):
 
     def __eq__(self, other):
         if not isinstance(other, ChordProgression):
-            raise TypeError("Cannot compare ChordProgression object with {} object".format(type(other)))
+            raise TypeError(f"Cannot compare ChordProgression object with {type(other)} object")
         if len(self) != len(other):
             return False
         for c, o in zip(self, other):
@@ -62,45 +63,50 @@ class ChordProgression(object):
         return not self.__eq__(other)
 
     @property
-    def chords(self):
-        """ Get component chords of chord progression
-
-        :rtype: list[pychord.Chord]
-        """
+    def chords(self) -> List[Chord]:
+        """ Get component chords of chord progression """
         return self._chords
 
-    def append(self, chord):
+    def append(self, chord: Union[str, Chord]) -> None:
         """ Append a chord to chord progressions
 
-        :type chord: str|pychord.Chord
         :param chord: A chord to append
-        :return:
         """
-        self._chords.append(as_chord(chord))
+        self._chords.append(self._as_chord(chord))
 
-    def insert(self, index, chord):
+    def insert(self, index: int, chord: Union[str, Chord]) -> None:
         """ Insert a chord to chord progressions
 
-        :param int index: Index to insert a chord
-        :type chord: str|pychord.Chord
+        :param index: Index to insert a chord
         :param chord: A chord to insert
-        :return:
         """
-        self._chords.insert(index, as_chord(chord))
+        self._chords.insert(index, self._as_chord(chord))
 
-    def pop(self, index=-1):
+    def pop(self, index: int = -1) -> Chord:
         """ Pop a chord from chord progressions
 
-        :param int index: Index of the chord to pop (default: -1)
-        :return: pychord.Chord
+        :param index: Index of the chord to pop (default: -1)
         """
         return self._chords.pop(index)
 
-    def transpose(self, trans):
+    def transpose(self, trans: int) -> None:
         """ Transpose whole chord progressions
 
-        :param int trans: Transpose key
-        :return:
+        :param trans: Transpose key
         """
         for chord in self._chords:
             chord.transpose(trans)
+
+    @staticmethod
+    def _as_chord(chord: Union[str, Chord]) -> Chord:
+        """ Convert from str to Chord instance if input is str
+
+        :param chord: Chord name or Chord instance
+        :return: Chord instance
+        """
+        if isinstance(chord, Chord):
+            return chord
+        elif isinstance(chord, str):
+            return Chord(chord)
+        else:
+            raise TypeError("input type should be str or Chord instance.")

--- a/pychord/quality.py
+++ b/pychord/quality.py
@@ -1,24 +1,22 @@
-# -*- coding: utf-8 -*-
 import copy
 from collections import OrderedDict
+from typing import Tuple, List
 
 from .constants.qualities import DEFAULT_QUALITIES
 from .utils import note_to_val, val_to_note
 
 
-class Quality(object):
-    """ Chord quality
+class Quality:
+    """ Chord quality """
 
-    :param str _quality: str expression of chord quality
-    """
-    def __init__(self, name, components):
+    def __init__(self, name: str, components: Tuple[int, ...]):
         """ Constructor of chord quality
 
-        :param str name: name of quality
-        :param Tuple[int]: components of quality
+        :param name: name of quality
+        :param components: components of quality
         """
-        self._quality = name
-        self.components = list(components)
+        self._quality: str = name
+        self.components: Tuple[int, ...] = components
 
     def __unicode__(self):
         return self._quality
@@ -28,7 +26,7 @@ class Quality(object):
 
     def __eq__(self, other):
         if not isinstance(other, Quality):
-            raise TypeError("Cannot compare Quality object with {} object".format(type(other)))
+            raise TypeError(f"Cannot compare Quality object with {type(other)} object")
         return self.components == other.components
 
     def __ne__(self, other):
@@ -68,43 +66,22 @@ class Quality(object):
         root_val = note_to_val(root)
         on_chord_val = note_to_val(on_chord) - root_val
 
-        list_ = list(self.components)
-        for idx, val in enumerate(list_):
+        components = list(self.components)
+        for idx, val in enumerate(self.components):
             if val % 12 == on_chord_val:
-                self.components.remove(val)
+                components.remove(val)
                 break
 
         if on_chord_val > root_val:
             on_chord_val -= 12
 
-        if on_chord_val not in self.components:
-            self.components.insert(0, on_chord_val)
+        if on_chord_val not in components:
+            components.insert(0, on_chord_val)
 
-    def append_note(self, note, root, scale=0):
-        """ Append a note to quality
-
-        :param str note: note to append on quality
-        :param str root: root note of chord
-        :param int scale: key scale
-        """
-        root_val = note_to_val(root)
-        note_val = note_to_val(note) - root_val + scale * 12
-        if note_val not in self.components:
-            self.components.append(note_val)
-            self.components.sort()
-
-    def append_notes(self, notes, root, scale=0):
-        """ Append notes to quality
-
-        :param list[str] notes: notes to append on quality
-        :param str root: root note of chord
-        :param int scale: key scale
-        """
-        for note in notes:
-            self.append_note(note, root, scale)
+        self.components = tuple(components)
 
 
-class QualityManager(object):
+class QualityManager:
     """ Singleton class to manage the qualities """
 
     def __new__(cls, *args, **kwargs):
@@ -118,27 +95,27 @@ class QualityManager(object):
             (q, Quality(q, c)) for q, c in DEFAULT_QUALITIES
         ])
 
-    def get_quality(self, name):
+    def get_quality(self, name: str) -> Quality:
         if name not in self._qualities:
-            raise ValueError("Unknown quality: {}".format(name))
+            raise ValueError(f"Unknown quality: {name}")
         # Create a new instance not to affect any existing instances
         return copy.deepcopy(self._qualities[name])
 
-    def set_quality(self, name, components):
+    def set_quality(self, name: str, components: Tuple[int, ...]):
         """ Set a Quality
 
         This method will not affect any existing Chord instances.
-        :param str name: name of quality
-        :param Tuple[int] components: components of quality
+        :param name: name of quality
+        :param components: components of quality
         """
         self._qualities[name] = Quality(name, components)
 
-    def find_quality_from_components(self, components):
+    def find_quality_from_components(self, components: List[int]):
         """ Find a quality from components
 
-        :param Tuple[int] components: components of quality
+        :param components: components of quality
         """
         for q in self._qualities.values():
-            if q.components == list(components):
+            if list(q.components) == components:
                 return copy.deepcopy(q)
         return None

--- a/pychord/utils.py
+++ b/pychord/utils.py
@@ -1,60 +1,52 @@
-# -*- coding: utf-8 -*-
+from typing import List
 
 from .constants import NOTE_VAL_DICT, SCALE_VAL_DICT
 
 
-def note_to_val(note):
-    """ Convert note to int
+def note_to_val(note: str) -> int:
+    """ Get index value of a note
 
     >>> note_to_val("C")
     0
     >>> note_to_val("B")
     11
-
-    :type note: str
-    :rtype: int
     """
     if note not in NOTE_VAL_DICT:
-        raise ValueError("Unknown note {}".format(note))
+        raise ValueError(f"Unknown note {note}")
     return NOTE_VAL_DICT[note]
 
 
-def val_to_note(val, scale="C"):
-    """ Convert int to note
+def val_to_note(val: int, scale: str = "C") -> str:
+    """ Return note by index in a scale
 
     >>> val_to_note(0)
     "C"
     >>> val_to_note(11, "D")
     "D#"
-
-    :type val: int
-    :param str scale: key scale
-    :rtype: str
     """
     val %= 12
     return SCALE_VAL_DICT[scale][val]
 
 
-def transpose_note(note, transpose, scale="C"):
+def transpose_note(note: str, transpose: int, scale: str = "C") -> str:
     """ Transpose a note
 
-    :param str note: note to transpose
-    :type transpose: int
-    :param str scale: key scale
-    :rtype: str
-    :return: transposed note
+    >>> transpose_note("C", 1)
+    "Db"
+    >>> transpose_note("D", 4, "A")
+    "F#"
     """
     val = note_to_val(note)
     val += transpose
     return val_to_note(val, scale)
 
 
-def display_appended(appended):
+def display_appended(appended: List[str]) -> str:
     # TODO: Implement this
     return ""
 
 
-def display_on(on_note):
+def display_on(on_note: str) -> str:
     if on_note:
-        return "/{}".format(on_note)
+        return f"/{on_note}"
     return ""

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,26 @@
+import sys
+
 from setuptools import setup, find_packages
 version = '0.6.3'
+
+CURRENT_PYTHON = sys.version_info[:2]
+REQUIRED_PYTHON = (3, 6)
+
+if CURRENT_PYTHON < REQUIRED_PYTHON:
+    sys.stderr.write("""PyChords only supports Python 3.6 and above.""")
+    sys.exit(1)
 
 setup(
     name='pychord',
     version=version,
     description="A library to handle musical chords in python.",
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable"
         "Environment :: Console",
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3 :: Only",
         "Topic :: Multimedia :: Sound/Audio",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Utilities",
@@ -18,7 +28,7 @@ setup(
         ],
     keywords='music chord',
     author='Yuma Mihira',
-    author_email='info@yurax2.com',
+    author_email='info@yuma.cloud',
     url='https://github.com/yuma-m/pychord',
     license='MIT',
     packages=find_packages(exclude=['test']),
@@ -27,4 +37,5 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     test_suite='test',
+    python_requires=">=3.6",
 )

--- a/test/test_chord.py
+++ b/test/test_chord.py
@@ -1,9 +1,6 @@
-# -*- coding: utf-8 -*-
-
 import unittest
 
 from pychord import Chord
-from pychord.chord import as_chord
 
 
 class TestChordCreations(unittest.TestCase):
@@ -73,24 +70,6 @@ class TestChordCreations(unittest.TestCase):
         c = Chord("C")
         with self.assertRaises(TypeError):
             print(c == 0)
-
-
-class TestAsChord(unittest.TestCase):
-
-    def test_as_chord_chord_input(self):
-        c = Chord("C")
-        ac = as_chord(c)
-        self.assertEqual(c, ac)
-
-    def test_as_chord_str_input(self):
-        chord = "C"
-        c = Chord(chord)
-        ac = as_chord(chord)
-        self.assertEqual(c, ac)
-
-    def test_as_chord_invalid_input(self):
-        with self.assertRaises(TypeError):
-            as_chord(1)
 
 
 class TestChordFromNoteIndex(unittest.TestCase):

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import unittest
 
 from pychord import Chord
@@ -7,7 +5,8 @@ from pychord import Chord
 
 class TestChordComponent(unittest.TestCase):
     def _assert_components(self, chord, qualities, notes):
-        """Validates if a chord is made up of specified qualities and notes.
+        """ Validates if a chord is made up of specified qualities and notes.
+
         :param str chord: A chord, specified as a string, e.g. "C7"
         :param qualities: The expected qualities of the chord, as a list of numbers
         :param notes: The expected notes of the chord, either as a list of strings,
@@ -90,18 +89,18 @@ class TestChordComponent(unittest.TestCase):
         self.assertEqual(com0, [1, 4, 7, 11, 14])
         com1 = c.components(visible=True)
         self.assertEqual(com1, ["C#", "E", "G", "B", "D"])
-    
+
     def test_major_add9(self):
-        # mmajor add 9 is a major chord with a Major ninth
+        # major add 9 is a major chord with a Major ninth
         base = Chord("C")
         base0 = list(base.components(visible=False))
         base1 = list(base.components(visible=True))
         c = Chord("CMadd9")
         com0 = c.components(visible=False)
-        self.assertEqual(com0,  base0 + [14])
+        self.assertEqual(com0, base0 + [14])
         com1 = c.components(visible=True)
         self.assertEqual(com1, base1 + ["D"])
-    
+
     def test_add4(self):
         self._assert_components("Cadd4", [0, 4, 5, 7], "C E F G")
 
@@ -111,18 +110,19 @@ class TestChordComponent(unittest.TestCase):
 
     def test_minor_add4(self):
         self._assert_components("Cmadd4", [0, 3, 5, 7], "C Eb F G")
-    
+
     def test_minor7_add11(self):
         self._assert_components('Cm7add11', [0, 3, 7, 10, 17], "C Eb G Bb F")
-    
+
     def test_major7_add11(self):
         self._assert_components('CM7add11', [0, 4, 7, 11, 17], "C E G B F")
-    
+
     def test_minormajor7_add11(self):
         self._assert_components('CmM7add11', [0, 3, 7, 11, 17], "C Eb G B F")
-    
+
     def test_major7_add13(self):
         self._assert_components("CM7add13", [0, 4, 7, 9, 11, 14], "C E G A B D")
+
 
 class TestChordComponentWithPitch(unittest.TestCase):
 

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import unittest
 
 from pychord.constants import NOTE_VAL_DICT, VAL_NOTE_DICT

--- a/test/test_progression.py
+++ b/test/test_progression.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import unittest
 
 from pychord import Chord, ChordProgression
@@ -20,6 +18,11 @@ class TestChordProgressionCreations(unittest.TestCase):
         c = "C"
         cp = ChordProgression(c)
         self.assertEqual(cp.chords, [Chord(c)])
+
+    def test_one_chord_invalid_type(self):
+        c = 1
+        with self.assertRaises(TypeError):
+            ChordProgression(c)
 
     def test_one_chord_list(self):
         c = Chord("C")

--- a/test/test_quality.py
+++ b/test/test_quality.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from pychord import QualityManager, Chord, note_to_chord
+from pychord import QualityManager, Chord, find_chords_from_notes
 
 
 class TestQuality(unittest.TestCase):
@@ -59,7 +59,7 @@ class TestOverwriteQuality(unittest.TestCase):
 
     def test_find_from_components(self):
         self.quality_manager.set_quality("13", (0, 4, 7, 10, 14, 17, 21))
-        chords = note_to_chord(['C', 'E', 'G', 'Bb', 'D', 'F', 'A'])
+        chords = find_chords_from_notes(['C', 'E', 'G', 'Bb', 'D', 'F', 'A'])
         self.assertEqual(chords, [Chord("C13")])
 
     def test_keep_existing_chord(self):

--- a/test/test_transpose.py
+++ b/test/test_transpose.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import unittest
 
 from pychord import Chord


### PR DESCRIPTION
Drop Python 2.7 and 3.5 compatibility and optimize for Python 3.6 and above.

closes #38.