### PR TITLE
Adds ordered inversion of chords

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,22 @@ True
 ['C', 'E', 'G', 'Bb', 'D', 'F']
 ```
 
+### Inversions
+
+Chord inversions are created with a forward slash and a number
+indicating the order. This can optionally be combined with an
+additional forward slash to change the bass note:
+
+```python
+>>> Chord("C/1").components() # First inversion of C
+['E', 'G', 'C']
+>>> Chord("C/2").components() # Second inversion of C
+['G', 'C', 'E']
+
+>>> Chord("Cm7/3/F").components() # Third inversion of Cm7 with an added F bass
+['F', 'Bb', 'C', 'Eb', 'G']
+```
+
 ## Examples
 
 - [pychord-midi.py](./examples/pychord-midi.py) - Create a MIDI file using PyChord and pretty_midi.

--- a/pychord/chord.py
+++ b/pychord/chord.py
@@ -16,7 +16,6 @@ class Chord:
         _quality: The quality of chord. (e.g. maj, m7, m7-5)
         _appended: The appended notes on chord.
         _on: The base note of slash chord.
-        _inversion: The order of inversion (eg. 0=none 1=1st 2=2nd ...)
     """
 
     def __init__(self, chord: str):
@@ -24,15 +23,14 @@ class Chord:
 
         :param chord: Name of chord (e.g. C, Am7, F#m7-5/A).
         """
-        root, quality, appended, on, inversion = parse(chord)
+        root, quality, appended, on = parse(chord)
         self._chord: str = chord
         self._root: str = root
         self._quality: Quality = quality
         self._appended: List[str] = appended
         self._on: str = on
-        self._inversion: int = inversion
 
-        self._append_on_chord_and_inversion()
+        self._append_on_chord()
 
     def __unicode__(self):
         return self._chord
@@ -143,11 +141,6 @@ class Chord:
         """ The base note of slash chord """
         return self._on
 
-    @property
-    def inversion(self):
-        """The order of the inversion"""
-        return self._inversion
-
     def info(self):
         """ Return information of chord to display """
         return f"""{self._chord}
@@ -188,17 +181,7 @@ on={self._on}"""
             components = [c + 12 for c in components]
         return [f"{val_to_note(c, scale=self._root)}{root_pitch + c // 12}" for c in components]
 
-    def _append_on_chord_and_inversion(self):
-        if self._inversion != 0:
-            note = val_to_note(
-                self._quality.components[self._inversion] + note_to_val(self.root)
-            )
-            self._quality.append_on_chord(
-                note,
-                self.root,
-            )
-            if not self._on:
-                self._on = note
+    def _append_on_chord(self):
         if self._on:
             self._quality.append_on_chord(self.on, self.root)
 

--- a/pychord/parser.py
+++ b/pychord/parser.py
@@ -1,7 +1,10 @@
 from typing import Tuple, List
+import re
 
 from .quality import QualityManager, Quality
 from .utils import NOTE_VAL_DICT
+
+inversion_re = re.compile("/([0-9]+)")
 
 
 def parse(chord: str) -> Tuple[str, Quality, List[str], str]:
@@ -24,6 +27,13 @@ def parse(chord: str) -> Tuple[str, Quality, List[str], str]:
             raise ValueError(f"Invalid note {note}")
 
     check_note(root)
+
+    inversion = 0
+    inversion_m = inversion_re.search(rest)
+    if inversion_m:
+        inversion = int(inversion_m.group(1))
+        rest = inversion_re.sub("", rest)
+
     on_chord_idx = rest.find("/")
     if on_chord_idx >= 0:
         on = rest[on_chord_idx + 1:]
@@ -34,4 +44,4 @@ def parse(chord: str) -> Tuple[str, Quality, List[str], str]:
     quality = QualityManager().get_quality(rest)
     # TODO: Implement parser for appended notes
     appended: List[str] = []
-    return root, quality, appended, on
+    return root, quality, appended, on, inversion

--- a/pychord/parser.py
+++ b/pychord/parser.py
@@ -7,8 +7,8 @@ from .utils import NOTE_VAL_DICT
 inversion_re = re.compile("/([0-9]+)")
 
 
-def parse(chord: str) -> Tuple[str, Quality, List[str], str]:
-    """ Parse a string to get chord component
+def parse(chord: str) -> Tuple[str, Quality, List[str], str, int]:
+    """Parse a string to get chord component
 
     :param chord: str expression of a chord
     :return: (root, quality, appended, on)

--- a/pychord/parser.py
+++ b/pychord/parser.py
@@ -7,7 +7,7 @@ from .utils import NOTE_VAL_DICT
 inversion_re = re.compile("/([0-9]+)")
 
 
-def parse(chord: str) -> Tuple[str, Quality, List[str], str, int]:
+def parse(chord: str) -> Tuple[str, Quality, List[str], str]:
     """Parse a string to get chord component
 
     :param chord: str expression of a chord
@@ -41,7 +41,7 @@ def parse(chord: str) -> Tuple[str, Quality, List[str], str, int]:
         check_note(on)
     else:
         on = ""
-    quality = QualityManager().get_quality(rest)
+    quality = QualityManager().get_quality(rest, inversion)
     # TODO: Implement parser for appended notes
     appended: List[str] = []
-    return root, quality, appended, on, inversion
+    return root, quality, appended, on

--- a/pychord/quality.py
+++ b/pychord/quality.py
@@ -1,5 +1,4 @@
 import copy
-import math
 from collections import OrderedDict
 from typing import Tuple, List
 

--- a/pychord/quality.py
+++ b/pychord/quality.py
@@ -51,6 +51,8 @@ class Quality:
         if visible:
             components = [val_to_note(c, scale=root) for c in components]
 
+        # De-duplicate notes:
+        components = list(dict.fromkeys(components))
         return components
 
     def append_on_chord(self, on_chord, root):
@@ -76,7 +78,9 @@ class Quality:
             on_chord_val -= 12
 
         if on_chord_val not in components:
-            components.insert(0, on_chord_val)
+            components = [on_chord_val] + [
+                v for v in components if v % 12 != on_chord_val % 12
+            ]
 
         self.components = tuple(components)
 

--- a/pychord/quality.py
+++ b/pychord/quality.py
@@ -1,4 +1,5 @@
 import copy
+import math
 from collections import OrderedDict
 from typing import Tuple, List
 
@@ -104,7 +105,10 @@ class QualityManager:
         q = copy.deepcopy(self._qualities[name])
         # apply requested inversion :
         for i in range(inversion):
-            q.components = tuple(q.components[1:] + tuple([q.components[0]]))
+            n = q.components[0]
+            while n < q.components[-1]:
+                n += 12
+            q.components = q.components[1:] + (n,)
         return q
 
     def set_quality(self, name: str, components: Tuple[int, ...]):

--- a/pychord/quality.py
+++ b/pychord/quality.py
@@ -51,8 +51,6 @@ class Quality:
         if visible:
             components = [val_to_note(c, scale=root) for c in components]
 
-        # De-duplicate notes:
-        components = list(dict.fromkeys(components))
         return components
 
     def append_on_chord(self, on_chord, root):
@@ -99,11 +97,15 @@ class QualityManager:
             (q, Quality(q, c)) for q, c in DEFAULT_QUALITIES
         ])
 
-    def get_quality(self, name: str) -> Quality:
+    def get_quality(self, name: str, inversion: int = 0) -> Quality:
         if name not in self._qualities:
             raise ValueError(f"Unknown quality: {name}")
         # Create a new instance not to affect any existing instances
-        return copy.deepcopy(self._qualities[name])
+        q = copy.deepcopy(self._qualities[name])
+        # apply requested inversion :
+        for i in range(inversion):
+            q.components = tuple(q.components[1:] + tuple([q.components[0]]))
+        return q
 
     def set_quality(self, name: str, components: Tuple[int, ...]):
         """ Set a Quality

--- a/test/test_chord.py
+++ b/test/test_chord.py
@@ -60,27 +60,25 @@ class TestChordCreations(unittest.TestCase):
         c = Chord("C/1")
         self.assertEqual(c.root, "C")
         self.assertEqual(c.quality.quality, "")
-        self.assertEqual(c.components(), ["E", "C", "G"])
-        self.assertEqual(c, Chord("C/E"))
+        self.assertEqual(c.components(), ["E", "G", "C"])
 
     def test_2nd_order_inversion(self):
         c = Chord("C/2")
         self.assertEqual(c.root, "C")
         self.assertEqual(c.quality.quality, "")
         self.assertEqual(c.components(), ["G", "C", "E"])
-        self.assertEqual(c, Chord("C/G"))
 
     def test_inversion_complicated(self):
         c = Chord("Dm7b5/1")
         self.assertEqual(c.root, "D")
         self.assertEqual(c.quality.quality, "m7b5")
-        self.assertEqual(c.components(), ["F", "D", "G#", "C"])
+        self.assertEqual(c.components(), ["F", "G#", "C", "D"])
 
     def test_inversion_with_alternate_bass(self):
         c = Chord("C/1/F")
         self.assertEqual(c.root, "C")
         self.assertEqual(c.quality.quality, "")
-        self.assertEqual(c.components(), ["F", "E", "C", "G"])
+        self.assertEqual(c.components(), ["F", "E", "G", "C"])
 
     def test_eq(self):
         c1 = Chord("C")

--- a/test/test_chord.py
+++ b/test/test_chord.py
@@ -56,6 +56,32 @@ class TestChordCreations(unittest.TestCase):
     def test_invalid_slash_chord(self):
         self.assertRaises(ValueError, Chord, "C/H")
 
+    def test_1st_order_inversion(self):
+        c = Chord("C/1")
+        self.assertEqual(c.root, "C")
+        self.assertEqual(c.quality.quality, "")
+        self.assertEqual(c.components(), ["E", "C", "G"])
+        self.assertEqual(c, Chord("C/E"))
+
+    def test_2nd_order_inversion(self):
+        c = Chord("C/2")
+        self.assertEqual(c.root, "C")
+        self.assertEqual(c.quality.quality, "")
+        self.assertEqual(c.components(), ["G", "C", "E"])
+        self.assertEqual(c, Chord("C/G"))
+
+    def test_inversion_complicated(self):
+        c = Chord("Dm7b5/1")
+        self.assertEqual(c.root, "D")
+        self.assertEqual(c.quality.quality, "m7b5")
+        self.assertEqual(c.components(), ["F", "D", "G#", "C"])
+
+    def test_inversion_with_alternate_bass(self):
+        c = Chord("C/1/F")
+        self.assertEqual(c.root, "C")
+        self.assertEqual(c.quality.quality, "")
+        self.assertEqual(c.components(), ["F", "E", "C", "G"])
+
     def test_eq(self):
         c1 = Chord("C")
         c2 = Chord("C")
@@ -71,9 +97,14 @@ class TestChordCreations(unittest.TestCase):
         with self.assertRaises(TypeError):
             print(c == 0)
 
+    def test_components(self):
+        c = Chord("C/E")
+        quality_components_before = c.quality.components
+        c.components()
+        self.assertEqual(c.quality.components, quality_components_before)
+
 
 class TestChordFromNoteIndex(unittest.TestCase):
-
     def test_note_1(self):
         chord = Chord.from_note_index(note=1, quality="", scale="Cmaj")
         self.assertEqual(chord, Chord("C"))

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -158,5 +158,6 @@ class TestChordComponentWithPitch(unittest.TestCase):
         com = c.components_with_pitch(root_pitch=4)
         self.assertEqual(com, ['E6', 'G6', 'B6', 'D7', 'F7', 'G#7'])
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -118,6 +118,45 @@ class TestChordComponentWithPitch(unittest.TestCase):
         com = c.components_with_pitch(root_pitch=5)
         self.assertEqual(com, ["E5", "G#5", "B5", "F#6"])
 
+    def test_first_order_inversion(self):
+        c = Chord("G/1")
+        com = c.components_with_pitch(root_pitch=4)
+        self.assertEqual(com, ["B4", "D5", "G5"])
+        c2 = Chord("G13b9/1")
+        com2 = c2.components_with_pitch(root_pitch=4)
+        self.assertEqual(com2, ['B4', 'D5', 'F5', 'G#5', 'E6', 'G6'])
+
+    def test_second_order_inversion(self):
+        c = Chord("G/2")
+        com = c.components_with_pitch(root_pitch=4)
+        self.assertEqual(com, ["D5", "G5", "B5"])
+        c2 = Chord("G13b9/2")
+        com2 = c2.components_with_pitch(root_pitch=4)
+        self.assertEqual(com2, ['D5', 'F5', 'G#5', 'E6', 'G6', 'B6'])
+
+    def test_third_order_inversion(self):
+        c = Chord("Cm7/3")
+        com = c.components_with_pitch(root_pitch=4)
+        self.assertEqual(com, ['Bb4', 'C5', 'Eb5', 'G5'])
+        c2 = Chord("F#7/3")
+        com2 = c2.components_with_pitch(root_pitch=4)
+        self.assertEqual(com2, ['E5', 'F#5', 'A#5', 'C#6'])
+        c3 = Chord("G13b9/3")
+        com3 = c3.components_with_pitch(root_pitch=4)
+        self.assertEqual(com3, ['F5', 'G#5', 'E6', 'G6', 'B6', 'D7'])
+
+    def test_fourth_order_inversion(self):
+        c = Chord("F7b9")
+        com = c.components_with_pitch(root_pitch=4)
+        self.assertEqual(com, ['F4', 'A4', 'C5', 'Eb5', 'Gb5'])
+        c2 = Chord("G13b9/4")
+        com2 = c2.components_with_pitch(root_pitch=4)
+        self.assertEqual(com2, ['G#5', 'E6', 'G6', 'B6', 'D7', 'F7'])
+
+    def test_fifth_order_inversion(self):
+        c = Chord("G13b9/5")
+        com = c.components_with_pitch(root_pitch=4)
+        self.assertEqual(com, ['E6', 'G6', 'B6', 'D7', 'F7', 'G#7'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_transpose.py
+++ b/test/test_transpose.py
@@ -32,6 +32,16 @@ class TestChordCreations(unittest.TestCase):
         self.assertEqual(c.root, "C")
         self.assertEqual(c.quality.quality, "m7")
         self.assertEqual(c.on, "Bb")
+        self.assertEqual(c._chord, Chord("Cm7/Bb")._chord)
+        self.assertEqual(c.quality.components, Chord("Cm7/Bb").quality.components)
+        self.assertEqual(c, Chord("Cm7/Bb"))
+
+    def test_transpose_inversion(self):
+        c = Chord("Am7/3")
+        c.transpose(3)
+        self.assertEqual(c.root, "C")
+        self.assertEqual(c.quality.quality, "m7")
+        self.assertEqual(c.on, "Bb")
         self.assertEqual(c, Chord("Cm7/Bb"))
 
     def test_invalid_transpose_type(self):

--- a/test/test_transpose.py
+++ b/test/test_transpose.py
@@ -41,8 +41,6 @@ class TestChordCreations(unittest.TestCase):
         c.transpose(3)
         self.assertEqual(c.root, "C")
         self.assertEqual(c.quality.quality, "m7")
-        self.assertEqual(c.on, "Bb")
-        self.assertEqual(c, Chord("Cm7/Bb"))
 
     def test_invalid_transpose_type(self):
         c = Chord("Am")


### PR DESCRIPTION
Hi there, I'm not a trained musician. I have learned a lot of music theory just by looking at this code.
I want to do some chord inversions, and I learned that you can specify an inversion by using the slash notation `C/E` or `C/G` for the 1st and 2nd inversions of C. Cool! Now, how about a different chord? The note and the slash has to change and I have to already know what the second or third note of the new chord is, in order to do an inversion of the first. It makes me think about it before I can ask it to invert it.

However,  what I would like to do is say "Give me the 1st order inversion of the chord C major, whatever it is" and to do it without me having to know what the second note of the chord is. So, my proposed syntax for that is `C/1`, which would give me the exact same chord as `C/E`.

For example:

```
>>> Chord("C").components()
['C', 'E', 'G']

>>> Chord("C/1").components()
['E', 'C', 'G']

>>> Chord("C/2").components()
['G', 'C', 'E']

>>> Chord("C/1") == Chord("C/E")
True
```

I also learned that in jazz you can have an alternative bass note that may not be in the original chord, and you can do that with slash notation too (eg. `C/F`, which is `['F', 'C', 'E', 'G']`), but what if I also want an inversion of the C chord at the same time? The proposed syntax for that is to use double slashes: `C/1/F`, `C/2/F` for the first and second inversions of C and with an F bass added:

```
>>> Chord("C/F").components()
['F', 'C', 'E', 'G']

>>> Chord("C/1/F").components()
['F', 'E', 'C', 'G']

>>> Chord("C/2/F").components()
['F', 'G', 'C', 'E']
```

This syntax may be weird, especially for trained musicians, and I can understand if you don't want to include this in your library, but I thought I'd share, I'm open to considering alternative syntaxes or reimplementations, or if I have missed part of the existing functionality that already does this? I hope this can be of use to your library. Thanks again, Ryan.

