### PR TITLE
Fix missing dependencies for sphinx

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,3 +7,7 @@ build:
 
 sphinx:
   configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==9.1.0
+sphinx_rtd_theme==3.1.0


### PR DESCRIPTION
This PR fixes the documentation build error: `sphinx.errors.ThemeError: no theme named 'sphinx_rtd_theme' found (missing theme.toml?)`.