### PR TITLE
Fix the second note of Gm and Gdim

### DIFF
--- a/pychord/utils.py
+++ b/pychord/utils.py
@@ -33,18 +33,28 @@ def val_to_note(
     if index is None or quality is None:
         return SCALE_VAL_DICT[scale][val]
 
+    # NOTE: Is there a better way to implement this?
     is_flatted = (
-        (quality.find("dim") >= 0 and index == 1)
+        (quality.startswith("dim") and index == 1)
         or (
             (
                 quality.find("b5") >= 1
                 or quality.find("-5") >= 1
-                or quality.find("dim") >= 0
+                or quality.startswith("dim")
             )
             and index == 2
         )
         or ((quality == "dim7") and index == 3)
         or ((quality.find("b9") >= 1 or quality.find("-9") >= 1) and index == 4)
+        # TODO: Remove special logic below for Gm
+        or (
+            val == 10
+            and index == 1
+            and (
+                (quality.startswith("m") and not quality.startswith("maj"))
+                or quality.startswith("dim")
+            )
+        )
     )
     if is_flatted:
         temp = SCALE_VAL_DICT[scale][(val + 1) % 12]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pychord"
-version = "1.3.1"
+version = "1.3.2"
 description = "Package to handle musical chords"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -1,6 +1,7 @@
 import unittest
 
 from parameterized import parameterized
+
 from pychord import Chord
 
 
@@ -8,12 +9,14 @@ class TestChordComponent(unittest.TestCase):
     @parameterized.expand(
         [
             ("C", [0, 4, 7], ["C", "E", "G"]),
+            ("Gm", [7, 10, 14], ["G", "Bb", "D"]),
             ("Am", [9, 12, 16], ["A", "C", "E"]),
             ("Bdim", [11, 14, 17], ["B", "D", "F"]),
             ("Cdim", [0, 3, 6], ["C", "Eb", "Gb"]),
             ("Dbdim", [1, 4, 7], ["Db", "Fb", "Abb"]),
             ("Ddim", [2, 5, 8], ["D", "F", "Ab"]),
             ("Gbdim", [6, 9, 12], ["Gb", "Bbb", "Dbb"]),
+            ("Gdim", [7, 10, 13], ["G", "Bb", "Db"]),
             ("Cdim7", [0, 3, 6, 9], ["C", "Eb", "Gb", "Bbb"]),
             ("Dbdim7", [1, 4, 7, 10], ["Db", "Fb", "Abb", "Bb"]),
             ("Dbaug", [1, 5, 9], ["Db", "F", "A"]),
@@ -21,6 +24,7 @@ class TestChordComponent(unittest.TestCase):
             ("CM9/D", [-10, 0, 4, 7, 11], ["D", "C", "E", "G", "B"]),
             ("Fsus4", [5, 10, 12], ["F", "Bb", "C"]),
             ("G7", [7, 11, 14, 17], ["G", "B", "D", "F"]),
+            ("Gm7", [7, 10, 14, 17], ["G", "Bb", "D", "F"]),
             ("C6", [0, 4, 7, 9], ["C", "E", "G", "A"]),
             ("C#m7b9b5", [1, 4, 7, 11, 14], ["C#", "E", "G", "B", "D"]),
             ("Db5", [1, 8], ["Db", "Ab"]),


### PR DESCRIPTION
This PR is a workaround for #107. I think there should be a better way to handle this special case: https://github.com/yuma-m/pychord/issues/107#issuecomment-3772649927