### PR TITLE
Get rid of `NOTE_VAL_DICT` and `VAL_NOTE_DICT` constants

### DIFF
--- a/pychord/chord.py
+++ b/pychord/chord.py
@@ -1,10 +1,9 @@
 from typing import Any, Literal, overload
 
-from .constants import NOTE_VAL_DICT, VAL_NOTE_DICT
 from .constants.scales import RELATIVE_KEY_DICT
-from .parser import parse
-from .quality import QualityManager, Quality
-from .utils import transpose_note, note_to_val
+from .parser import parse, parse_scale
+from .quality import QualityManager, Quality, scale_notes
+from .utils import augment, diminish, transpose_note, note_to_val
 
 
 class Chord:
@@ -74,16 +73,20 @@ class Chord:
         :param diatonic: If True, chord quality is determined using the base scale (overrides ``quality``).
         :param chromatic: Lower or raise the scale degree (and all notes of the chord) by semitone(s).
         """
-        if not 1 <= note <= 8:
+        if not 1 <= note <= 7:
             raise ValueError(f"Invalid note {note}")
-        relative_key = RELATIVE_KEY_DICT[scale[-3:]][note - 1]
-        root_num = NOTE_VAL_DICT[scale[:-3]] + chromatic
-        root = VAL_NOTE_DICT[(root_num + relative_key) % 12][0]
-
-        scale_degrees = RELATIVE_KEY_DICT[scale[-3:]]
+        scale_root, scale_mode = parse_scale(scale)
+        root = scale_notes(scale_root, scale_mode)[note - 1]
+        if chromatic != 0:
+            alter = augment if chromatic > 0 else diminish
+            for i in range(abs(chromatic)):
+                root = alter(root)
 
         if diatonic:
+            scale_degrees = RELATIVE_KEY_DICT[scale_mode]
+
             # construct the chord based on scale degrees, within 1 octave
+            first = scale_degrees[note - 1]
             third = scale_degrees[(note + 1) % 7]
             fifth = scale_degrees[(note + 3) % 7]
             seventh = scale_degrees[(note + 5) % 7]
@@ -104,10 +107,10 @@ class Chord:
                 return uninverted
 
             if quality in ["", "-", "maj", "m", "min"]:
-                triad = (relative_key, third, fifth)
+                triad = (first, third, fifth)
                 q = get_diatonic_chord(triad)
             elif quality in ["7", "M7", "maj7", "m7"]:
-                seventh_chord = (relative_key, third, fifth, seventh)
+                seventh_chord = (first, third, fifth, seventh)
                 q = get_diatonic_chord(seventh_chord)
             else:
                 raise NotImplementedError(

--- a/pychord/constants/__init__.py
+++ b/pychord/constants/__init__.py
@@ -1,3 +1,0 @@
-from .scales import NOTE_VAL_DICT, VAL_NOTE_DICT, SCALE_VAL_DICT
-
-__all__ = ["NOTE_VAL_DICT", "VAL_NOTE_DICT", "SCALE_VAL_DICT"]

--- a/pychord/constants/scales.py
+++ b/pychord/constants/scales.py
@@ -1,17 +1,3 @@
-VAL_NOTE_DICT = {
-    0: ["C", "Dbb"],
-    1: ["Db", "C#"],
-    2: ["D", "Ebb", "C##"],
-    3: ["Eb", "Fbb", "D#"],
-    4: ["E", "D##"],
-    5: ["F", "Gbb"],
-    6: ["F#", "Gb"],
-    7: ["G", "Abb", "F##"],
-    8: ["Ab", "G#"],
-    9: ["A", "Bbb", "G##"],
-    10: ["Bb", "A#", "Cbb"],
-    11: ["B", "Cb", "A##"],
-}
 NOTE_VALUES = {
     "C": 0,
     "D": 2,
@@ -21,10 +7,6 @@ NOTE_VALUES = {
     "A": 9,
     "B": 11,
 }
-NOTE_VAL_DICT = {}
-for val, notes in VAL_NOTE_DICT.items():
-    for note in notes:
-        NOTE_VAL_DICT[note] = val
 
 SHARPED_SCALE = {
     0: "C",

--- a/pychord/parser.py
+++ b/pychord/parser.py
@@ -1,11 +1,24 @@
 import re
 
+from .constants.scales import RELATIVE_KEY_DICT
 from .quality import QualityManager, Quality
 
 # We accept notes with up to two flats or two sharps.
 note_re = re.compile("^[A-G](b{0,2}|#{0,2})$")
 
 inversion_re = re.compile("/([0-9]+)")
+
+
+def _check_mode(mode: str) -> None:
+    """Raise ValueError if mode is invalid"""
+    if mode not in RELATIVE_KEY_DICT:
+        raise ValueError(f"Invalid mode {mode}")
+
+
+def _check_note(note: str) -> None:
+    """Raise ValueError if note is invalid"""
+    if not note_re.match(note):
+        raise ValueError(f"Invalid note {note}")
 
 
 def parse(chord: str) -> tuple[str, Quality, str]:
@@ -26,12 +39,7 @@ def parse(chord: str) -> tuple[str, Quality, str]:
         root = chord[:1]
         rest = chord[1:]
 
-    def check_note(note: str) -> None:
-        """Raise ValueError if note is invalid"""
-        if not note_re.match(note):
-            raise ValueError(f"Invalid note {note}")
-
-    check_note(root)
+    _check_note(root)
 
     inversion = 0
     inversion_m = inversion_re.search(rest)
@@ -43,8 +51,21 @@ def parse(chord: str) -> tuple[str, Quality, str]:
     if on_chord_idx >= 0:
         on = rest[on_chord_idx + 1 :]
         rest = rest[:on_chord_idx]
-        check_note(on)
+        _check_note(on)
     else:
         on = ""
     quality = QualityManager().get_quality(rest, inversion)
     return root, quality, on
+
+
+def parse_scale(scale: str) -> tuple[str, str]:
+    """
+    Parse a string representing a scale into its root and mode.
+    """
+    root = scale[:-3]
+    mode = scale[-3:]
+
+    _check_note(root)
+    _check_mode(mode)
+
+    return (root, mode)

--- a/pychord/quality.py
+++ b/pychord/quality.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, overload
 
 from .constants.qualities import DEFAULT_QUALITIES
 from .constants.scales import RELATIVE_KEY_DICT
-from .utils import note_to_val
+from .utils import augment, diminish, note_to_val
 
 
 class Quality:
@@ -135,13 +135,13 @@ def _apply_interval_to_note(root: str, interval: str) -> str:
     alterations, offset = _parse_interval(interval)
 
     # Apply the interval and alteration.
-    notes_in_key = _major_scale_notes(root)
+    notes_in_key = scale_notes(root, "maj")
     note = notes_in_key[offset % 7]
     for alteration in alterations:
         if alteration == "#":
-            note = _augment(note)
+            note = augment(note)
         else:
-            note = _diminish(note)
+            note = diminish(note)
     return note
 
 
@@ -165,55 +165,41 @@ def _parse_interval(interval: str) -> tuple[str, int]:
     return alterations, offset
 
 
-def _augment(note: str) -> str:
-    """
-    Augment the given note.
-    """
-    if note.endswith("b"):
-        return note[:-1]
-    else:
-        return note + "#"
-
-
-def _diminish(note: str) -> str:
-    """
-    Diminish the given note.
-    """
-    if note.endswith("#"):
-        return note[:-1]
-    else:
-        return note + "b"
-
-
 @functools.lru_cache()
-def _major_scale_notes(root: str) -> list[str]:
+def scale_notes(root: str, mode: str) -> list[str]:
     """
-    Return the list of note names in the given major scale.
+    Return the list of note names in the given scale.
     """
     alphabet = ["C", "D", "E", "F", "G", "A", "B"]
     root_val = note_to_val(root)
 
     # Determine whether we use a flatted or sharped scale.
     if root == "F" or len(root) > 1 and root[1] == "b":
-        alter = _diminish
+        alter = diminish
     else:
-        alter = _augment
+        alter = augment
 
     # Name notes in the key.
     notes = [root]
     index = alphabet.index(root[0])
-    for offset in RELATIVE_KEY_DICT["maj"][1:-1]:
+    for offset in RELATIVE_KEY_DICT[mode][1:-1]:
         index = (index + 1) % 7
         note_val = (root_val + offset) % 12
 
         # Find the accidental to match the pitch.
-        note = alphabet[index]
-        for i in range(3):
+        letter = alphabet[index]
+        for note in [
+            diminish(diminish(letter)),
+            diminish(letter),
+            letter,
+            augment(letter),
+            augment(augment(letter)),
+        ]:
             if note_to_val(note) == note_val:
                 notes.append(note)
                 break
             note = alter(note)
         else:
-            raise ValueError(f"{root} major scale requires too many accidentals")
+            raise ValueError(f"{root}{mode} scale requires too many accidentals")
 
     return notes

--- a/pychord/utils.py
+++ b/pychord/utils.py
@@ -1,5 +1,24 @@
-from .constants import SCALE_VAL_DICT
-from .constants.scales import NOTE_VALUES
+from .constants.scales import NOTE_VALUES, SCALE_VAL_DICT
+
+
+def augment(note: str) -> str:
+    """
+    Augment the given note.
+    """
+    if note.endswith("b"):
+        return note[:-1]
+    else:
+        return note + "#"
+
+
+def diminish(note: str) -> str:
+    """
+    Diminish the given note.
+    """
+    if note.endswith("#"):
+        return note[:-1]
+    else:
+        return note + "b"
 
 
 def note_to_val(note: str) -> int:

--- a/test/test_chord.py
+++ b/test/test_chord.py
@@ -116,31 +116,52 @@ class TestChordFromNoteIndex(unittest.TestCase):
     def test_from_note_index(self):
         for note, quality, scale, expected_chord_str in [
             (1, "", "Cmaj", "C"),
-            (2, "m7", "F#min", "Abm7"),  # wrong, should be G#m7
+            (2, "m7", "F#min", "G#m7"),
             (3, "sus2", "Cmin", "Ebsus2"),
             (7, "7", "Amin", "G7"),
-            (8, "", "Emaj", "E"),
         ]:
             with self.subTest(note=note, quality=quality, scale=scale):
                 chord = Chord.from_note_index(note=note, quality=quality, scale=scale)
                 self.assertEqual(str(chord), expected_chord_str)
 
-    def test_invalid_note_index(self):
-        for note, quality, scale in [
-            (0, "", "Cmaj"),
-            (9, "", "Fmaj"),
+    def test_from_note_index_with_chromatic(self):
+        for note, quality, scale, chromatic, expected_chord_str in [
+            (1, "", "Cmaj", -1, "Cb"),
+            (1, "", "Cmaj", 1, "C#"),
         ]:
-            with (
-                self.subTest(note=note, quality=quality, scale=scale),
-                self.assertRaises(ValueError),
+            with self.subTest(
+                note=note, quality=quality, scale=scale, chromatic=chromatic
             ):
-                Chord.from_note_index(note=note, quality=quality, scale=scale)
+                chord = Chord.from_note_index(
+                    note=note, quality=quality, scale=scale, chromatic=chromatic
+                )
+                self.assertEqual(str(chord), expected_chord_str)
+
+    def test_invalid_note_index(self):
+        for note, quality, scale, exception_str in [
+            (0, "", "Cmaj", "Invalid note 0"),
+            (8, "", "Fmaj", "Invalid note 8"),
+        ]:
+            with self.subTest(note=note, quality=quality, scale=scale):
+                with self.assertRaises(ValueError) as cm:
+                    Chord.from_note_index(note=note, quality=quality, scale=scale)
+                self.assertEqual(str(cm.exception), exception_str)
+
+    def test_invalid_scale(self):
+        for note, quality, scale, exception_str in [
+            (1, "", "Xmaj", "Invalid note X"),
+            (1, "", "Cbob", "Invalid mode bob"),
+        ]:
+            with self.subTest(note=note, quality=quality, scale=scale):
+                with self.assertRaises(ValueError) as cm:
+                    Chord.from_note_index(note=note, quality=quality, scale=scale)
+                self.assertEqual(str(cm.exception), exception_str)
 
     def test_diatonic_from_note_index(self):
         for note, quality, diatonic, scale, expected_chord_str in [
             (1, "", True, "Dmaj", "D"),
             (2, "7", True, "BLoc", "CM7"),
-            (3, "m", True, "G#Mix", "Cdim"),  # wrong, should be B#dim
+            (3, "m", True, "G#Mix", "B#dim"),
             (4, "-", True, "AbDor", "Db"),
         ]:
             with self.subTest(note=note, quality=quality, scale=scale):

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -109,7 +109,7 @@ class TestChordComponent(unittest.TestCase):
                     c.components()
                 self.assertEqual(
                     str(cm.exception),
-                    f"{chord} major scale requires too many accidentals",
+                    f"{chord}maj scale requires too many accidentals",
                 )
 
 

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -1,9 +1,0 @@
-import unittest
-
-from pychord.constants import NOTE_VAL_DICT, VAL_NOTE_DICT
-
-
-class TestConstants(unittest.TestCase):
-    def test_note_and_val(self):
-        for note, val in NOTE_VAL_DICT.items():
-            self.assertIn(note, VAL_NOTE_DICT[val])

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,9 +1,19 @@
 import unittest
 
-from pychord.utils import note_to_val
+from pychord.utils import augment, diminish, note_to_val
 
 
 class TestUtils(unittest.TestCase):
+    def test_augment(self):
+        self.assertEqual(augment("Cb"), "C")
+        self.assertEqual(augment("C"), "C#")
+        self.assertEqual(augment("C#"), "C##")
+
+    def test_diminish(self):
+        self.assertEqual(diminish("Cb"), "Cbb")
+        self.assertEqual(diminish("C"), "Cb")
+        self.assertEqual(diminish("C#"), "C")
+
     def test_note_to_val(self):
         self.assertEqual(note_to_val("C"), 0)
 


### PR DESCRIPTION
Use the `note_to_val` instead of `NOTE_VAL_DICT` as it can handle any number of alterations.

Use `_scale_notes` instead of `VAL_NOTE_DICT`.