### PR TITLE
Fix mypy error

### DIFF
--- a/pychord/quality.py
+++ b/pychord/quality.py
@@ -82,8 +82,10 @@ class QualityManager:
     Singleton class to manage the chord qualities.
     """
 
+    _instance: "QualityManager | None" = None
+
     def __new__(cls) -> "QualityManager":
-        if not hasattr(cls, "_instance"):
+        if cls._instance is None:
             cls._instance = super(QualityManager, cls).__new__(cls)
             cls._instance.load_default_qualities()
         return cls._instance


### PR DESCRIPTION
This PR fixes the following errors.

```
pychord/quality.py:88: error: Cannot access instance-only attribute "_instance" on class object  [misc]
pychord/quality.py:89: error: Cannot access instance-only attribute "_instance" on class object  [misc]
```